### PR TITLE
Update packages and the target environment for test projects.

### DIFF
--- a/build/azDevOps/packages-amido-stacks-testing.yml
+++ b/build/azDevOps/packages-amido-stacks-testing.yml
@@ -33,8 +33,8 @@ variables:
     value: "Stacks"
   - name: Package.Public
     value: true
-  - name: Package.nuget_service_connection
-    value: NuGetAmidoStacksServiceConnection
+  # - name: Package.nuget_service_connection
+  #  value: NuGetAmidoStacksServiceConnection
   - name: Package.Path
     value: "src/Amido.Stacks.Testing"
   - name: Test.Path
@@ -66,7 +66,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: amido/stacks-pipeline-templates
+      name: ensono/stacks-pipeline-templates
       ref: refs/tags/v2.0.1
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks
@@ -81,7 +81,7 @@ stages:
     jobs:
       - job: Validation
         pool:
-          vmImage: "ubuntu-18.04"
+          vmImage: "ubuntu-22.04"
         steps:
           - checkout: self
 
@@ -117,8 +117,8 @@ stages:
               package_feed: "$(Package.Feed)"
               publish_symbols: true
               publish_public: "$(Package.Public)"
-              nuget_service_connection: "$(Package.nuget_service_connection)"
+              nuget_service_connection: false
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables
-              dotnet_core_version: "3.1.x"
+              dotnet_core_version: "6.0.x"

--- a/build/azDevOps/packages-amido-stacks-testing.yml
+++ b/build/azDevOps/packages-amido-stacks-testing.yml
@@ -117,7 +117,7 @@ stages:
               package_feed: "$(Package.Feed)"
               publish_symbols: true
               publish_public: "$(Package.Public)"
-              nuget_service_connection: false
+              use_nuget_service_connection: false
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables

--- a/build/azDevOps/packages-amido-stacks-testing.yml
+++ b/build/azDevOps/packages-amido-stacks-testing.yml
@@ -30,7 +30,7 @@ variables:
     value: "$(self_pipeline_repo)/scripts"
   # Path specific for this package, change accordingly
   - name: Package.Feed
-    value: "Stacks"
+    value: ""
   - name: Package.Public
     value: true
   # - name: Package.nuget_service_connection
@@ -66,8 +66,8 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: ensono/stacks-pipeline-templates
-      ref: refs/tags/v2.0.1
+      name: Ensono/stacks-pipeline-templates
+      ref: refs/heads/feature/cycle4
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks
   containers:

--- a/build/azDevOps/packages-amido-stacks-testing.yml
+++ b/build/azDevOps/packages-amido-stacks-testing.yml
@@ -121,4 +121,4 @@ stages:
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables
-              dotnet_core_version: "6.0.x"
+              dotnet_core_version: "3.1.x"

--- a/build/azDevOps/packages-amido-stacks-testing.yml
+++ b/build/azDevOps/packages-amido-stacks-testing.yml
@@ -105,7 +105,7 @@ stages:
       - job: BuildDotNet
         dependsOn: Validation
         pool:
-          vmImage: "windows-2019"
+          vmImage: "windows-2022"
         continueOnError: false
         steps:
           - template: azDevOps/azure/templates/v2/steps/build-dotnet-package.yml@templates
@@ -121,4 +121,4 @@ stages:
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables
-              dotnet_core_version: "3.1.x"
+              dotnet_core_version: "6.0.x"

--- a/src/Amido.Stacks.Testing.Tests/Amido.Stacks.Testing.Tests.csproj
+++ b/src/Amido.Stacks.Testing.Tests/Amido.Stacks.Testing.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Amido.Stacks.Testing.Tests/Amido.Stacks.Testing.Tests.csproj
+++ b/src/Amido.Stacks.Testing.Tests/Amido.Stacks.Testing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Amido.Stacks.Testing/Amido.Stacks.Testing.csproj
+++ b/src/Amido.Stacks.Testing/Amido.Stacks.Testing.csproj
@@ -11,10 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />


### PR DESCRIPTION
### Update packages and the target environment for the test project.

#### 📲 What

Updating packages to their latest long term support release.  In this case, Microsoft extensions for configuration have been updated from v6.0.0 to 6.0.1.  Various testing packages used in the Amido.Stacks.Testing.Tests project have also been updated along with the target framework, which was previously _net472;netcoreapp3.1_, but has been updated to net472;net6.0 because netcoreapp3.1 is no longer supported.

#### 🤔 Why

Packages updates have been requested for .NET and Java Stacks as part of the latest Stacks cycle.

#### 🛠 How

Simple package updates and an update to the TargetFramework property in the in the  Amido.Stacks.Testing.Tests.csproj file.

#### 👀 Evidence

See the  Amido.Stacks.Testing.Tests.csproj file.

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?